### PR TITLE
Use strings instead of numbers in the spec file

### DIFF
--- a/spec/solver_spec.rb
+++ b/spec/solver_spec.rb
@@ -5,15 +5,15 @@ describe Solver do
 
   describe ".solve" do
     it 'takes an input 6624 and outputs 2' do
-      expect(Solver.solve(6624)).to eql 2
+      expect(Solver.solve('6624')).to eql 2
     end
 
     it 'takes an input 0000 and outputs 4' do
-      expect(Solver.solve(0000)).to eql 4
+      expect(Solver.solve('0000')).to eql 4
     end
 
     it 'takes an input 2357 and outputs 0' do
-      expect(Solver.solve(2357)).to eql 0
+      expect(Solver.solve('2357')).to eql 0
     end
   end
 


### PR DESCRIPTION
Numbers with leading zeros will retain those zeros after being passed
the function.
